### PR TITLE
Fix Counties Map Parsing Error

### DIFF
--- a/app/javascript/packs/state_map_utils.js
+++ b/app/javascript/packs/state_map_utils.js
@@ -66,7 +66,8 @@ exports.setupEventHandlers = (stateMap) => {
         const countyFipsCode = elem.attr('data-county-fips-code');
         const state = stateMap.state.symbol;
         const countyName = elem.attr('data-county-name');
-        const stateCounty = encodeURIComponent(`${countyName}, ${countyFipsCode}, ${state}`);
+        countyNameNew = countyName.split('.').join("");
+        const stateCounty = encodeURIComponent(`${countyNameNew}, ${countyFipsCode}, ${state}`);
         window.location.href = `/search/${stateCounty}`;
     };
     mapUtils.handleMapMouseEvents(targets, hoverHtmlProvider, clickCallback);

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -24,6 +24,8 @@ class Representative < ApplicationRecord
           photo_url_temp = official.photo_url if official.instance_variable_defined?(:@photo_url)
           unless official.address.nil?
             street_temp = official.address[0].line1
+            if street_temp.eql("St")
+              street_temp = "St. Louis County"
             city_temp = official.address[0].city
             state_temp = official.address[0].state
             zip_temp = official.address[0].zip

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -24,8 +24,6 @@ class Representative < ApplicationRecord
           photo_url_temp = official.photo_url if official.instance_variable_defined?(:@photo_url)
           unless official.address.nil?
             street_temp = official.address[0].line1
-            if street_temp.eql("St")
-              street_temp = "St. Louis County"
             city_temp = official.address[0].city
             state_temp = official.address[0].state
             zip_temp = official.address[0].zip


### PR DESCRIPTION
Previously, counties such as `St. Louis County` were not getting parsed correctly since the `.` was included in the URL, resulting in triggering the wrong route:
<img width="846" alt="image" src="https://github.com/cs169/fa23-chips-10.5-6/assets/69385518/0579a243-2d53-438d-a5b4-db1494fd8550">

This PR removes all instances of `.` in the county names in the URL.
